### PR TITLE
Fixed handling of ca cert file

### DIFF
--- a/lib/hiera/backend/http_backend.rb
+++ b/lib/hiera/backend/http_backend.rb
@@ -20,11 +20,11 @@ class Hiera
             @http.verify_mode = OpenSSL::SSL::VERIFY_PEER
           end
 
-          if @config[:ssl_cert]
-            store = OpenSSL::X509::Store.new
-            store.add_cert(OpenSSL::X509::Certificate.new(File.read(@config[:ssl_ca_cert])))
-            @http.cert_store = store
+          if @config[:ssl_ca_cert]
+            @http.ca_file = @config[:ssl_ca_cert]
+          end
 
+          if @config[:ssl_cert]
             @http.key = OpenSSL::PKey::RSA.new(File.read(@config[:ssl_cert]))
             @http.cert = OpenSSL::X509::Certificate.new(File.read(@config[:ssl_key]))
           end


### PR DESCRIPTION
I was trying to use your library somewhere where we have an internal CA.  It took me a while to dig through the code and realize that you could only use a ca cert if you were doing client auth.  I separated out the code and simplified to use the ca_file member.  If you'd like me to revert back to the store, I can.  This just seemed simpler to follow.
