### PR TITLE
Add key_whitelist option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ The following is an example hiera.yaml configuration for use with hiera-http
       :port: 5984
       :output: json
       :cache_timeout: 10
+      :key_whitelist:
+        - key1
+        - key2
+        - !ruby/regexp /app::.*/
       :failure: graceful
       :paths:
         - /configuration/%{fqdn}
@@ -35,6 +39,8 @@ The following are optional configuration parameters
 `:cache_timeout: ` : Timeout in seconds for HTTP requests to a same path (default 10)
 
 `:cache_clean_interval: ` : Interval (in secs) to clean the cache (default 3600), set to 0 to disable cache cleaning 
+
+`:key_whitelist: ` : If it is not nil, ignore keys not in the array (default nil).  The array can have strings and regexps.
 
 `:failure: ` : When set to `graceful` will stop hiera-http from throwing an exception in the event of a connection error, timeout or invalid HTTP response and move on.  Without this option set hiera-http will throw an exception in such circumstances
 

--- a/lib/hiera/backend/http_backend.rb
+++ b/lib/hiera/backend/http_backend.rb
@@ -15,6 +15,10 @@ class Hiera
         @cache_timeout = @config[:cache_timeout] || 10
         @cache_clean_interval = @config[:cache_clean_interval] || 3600
 
+        if @config[:key_whitelist]
+          @key_regexp = Regexp.union(@config[:key_whitelist])
+        end
+
         if @config[:use_ssl]
           @http.use_ssl = true
 
@@ -38,6 +42,8 @@ class Hiera
       end
 
       def lookup(key, scope, order_override, resolution_type)
+        return if @key_regexp && key[@key_regexp].to_s.bytesize != key.bytesize
+
         answer = nil
 
         paths = @config[:paths].map { |p| Backend.parse_string(p, scope, { 'key' => key }) }


### PR DESCRIPTION
Sometimes the HTTP content is not directly controlled by us (for example,
controlled by dev team). It is a good idea to enforce some restriction
on the untrusted content. key_whitelist option is the first step.