### PR TITLE
allow disabling the cache with disable_cache (default is false)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The following is an example hiera.yaml configuration for use with hiera-http
 
     :backends:
       - http
-     
+
     :http:
       :host: 127.0.0.1
       :port: 5984
@@ -34,7 +34,9 @@ The following are optional configuration parameters
 
 `:cache_timeout: ` : Timeout in seconds for HTTP requests to a same path (default 10)
 
-`:cache_clean_interval: ` : Interval (in secs) to clean the cache (default 3600), set to 0 to disable cache cleaning 
+`:cache_clean_interval: ` : Interval (in secs) to clean the cache (default 3600), set to 0 to disable cache cleaning
+
+`:disable_cache: ` : Disable the cache, only recommended for testing (default false)
 
 `:failure: ` : When set to `graceful` will stop hiera-http from throwing an exception in the event of a connection error, timeout or invalid HTTP response and move on.  Without this option set hiera-http will throw an exception in such circumstances
 
@@ -103,7 +105,7 @@ Theres a few things still on my list that I'm going to be adding, including
 
 * 1.0 release
 * Support for ignoring 404's when failure is not set to graceful
- 
+
 #### 0.1.0
 * Stable
 * Puppet Forge release
@@ -113,5 +115,3 @@ Theres a few things still on my list that I'm going to be adding, including
 
 #### 0.0.1
 * Initial release
-
-

--- a/lib/hiera/backend/http_backend.rb
+++ b/lib/hiera/backend/http_backend.rb
@@ -14,6 +14,7 @@ class Hiera
         @cache = {}
         @cache_timeout = @config[:cache_timeout] || 10
         @cache_clean_interval = @config[:cache_clean_interval] || 3600
+        @cache_disabled = @config[:disable_cache] || false
 
         if @config[:use_ssl]
           @http.use_ssl = true
@@ -48,7 +49,11 @@ class Hiera
 
           Hiera.debug("[hiera-http]: Lookup #{key} from #{@config[:host]}:#{@config[:port]}#{path}")
 
-          result = http_get_and_parse_with_cache(path)
+          result = if @cache_disabled
+                     http_get_and_parse(path)
+                   else
+                     http_get_and_parse_with_cache(path)
+                   end
           result = result[key] if result.is_a?(Hash)
           next if result.nil?
 
@@ -161,4 +166,3 @@ class Hiera
     end
   end
 end
-


### PR DESCRIPTION
this allows easier testing of hiera-http. e.g. configuration changes in
couchdb are immediately visible on the puppet master.