### PR TITLE
Whitelist (re-factored from #24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,6 @@ The following is an example hiera.yaml configuration for use with hiera-http
       :port: 5984
       :output: json
       :cache_timeout: 10
-      :key_whitelist:
-        - key1
-        - key2
-        - !ruby/regexp /app::.*/
       :failure: graceful
       :paths:
         - /configuration/%{fqdn}
@@ -40,7 +36,11 @@ The following are optional configuration parameters
 
 `:cache_clean_interval: ` : Interval (in secs) to clean the cache (default 3600), set to 0 to disable cache cleaning 
 
-`:key_whitelist: ` : If it is not nil, ignore keys not in the array (default nil).  The array can have strings and regexps.
+`:confine_to_keys: ` : Only use this backend if the key matches one of the regexes in the array
+
+      :confine_to_keys:
+        - "application.*"
+        - "apache::.*"
 
 `:failure: ` : When set to `graceful` will stop hiera-http from throwing an exception in the event of a connection error, timeout or invalid HTTP response and move on.  Without this option set hiera-http will throw an exception in such circumstances
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ The following is an example hiera.yaml configuration for use with hiera-http
       :port: 5984
       :output: json
       :cache_timeout: 10
+      :key_whitelist:
+        - key1
+        - key2
+        - !ruby/regexp /app::.*/
       :failure: graceful
       :paths:
         - /configuration/%{fqdn}
@@ -35,6 +39,8 @@ The following are optional configuration parameters
 `:cache_timeout: ` : Timeout in seconds for HTTP requests to a same path (default 10)
 
 `:cache_clean_interval: ` : Interval (in secs) to clean the cache (default 3600), set to 0 to disable cache cleaning 
+
+`:key_whitelist: ` : If it is not nil, ignore keys not in the array (default nil).  The array can have strings and regexps.
 
 `:failure: ` : When set to `graceful` will stop hiera-http from throwing an exception in the event of a connection error, timeout or invalid HTTP response and move on.  Without this option set hiera-http will throw an exception in such circumstances
 

--- a/lib/hiera/backend/http_backend.rb
+++ b/lib/hiera/backend/http_backend.rb
@@ -15,6 +15,14 @@ class Hiera
         @cache_timeout = @config[:cache_timeout] || 10
         @cache_clean_interval = @config[:cache_clean_interval] || 3600
 
+        @regex_key_match = nil
+
+        if confine_keys = @config[:confine_to_keys]
+          confine_keys.map! { |r| Regexp.new(r) }
+          @regex_key_match = Regexp.union(confine_keys)
+        end
+
+
         if @config[:use_ssl]
           @http.use_ssl = true
 
@@ -42,10 +50,10 @@ class Hiera
         # if confine_to_keys is configured, then only proceed if one of the
         # regexes matches the lookup key
         #
-        if @config[:confine_to_keys].is_a?(Array)
-          match = @config[:confine_to_keys].select { |r| key[Regexp.new(r)] }[0]
-          return nil unless match
+        if @regex_key_match
+          return nil unless key[@regex_key_match] == key
         end
+
 
         answer = nil
 

--- a/lib/hiera/backend/http_backend.rb
+++ b/lib/hiera/backend/http_backend.rb
@@ -15,6 +15,10 @@ class Hiera
         @cache_timeout = @config[:cache_timeout] || 10
         @cache_clean_interval = @config[:cache_clean_interval] || 3600
 
+        if @config[:key_whitelist]
+          @key_regexp = Regexp.union(@config[:key_whitelist])
+        end
+
         if @config[:use_ssl]
           @http.use_ssl = true
 
@@ -38,6 +42,8 @@ class Hiera
       end
 
       def lookup(key, scope, order_override, resolution_type)
+        return if @key_regexp && key[@key_regexp].to_s.bytesize != key.bytesize
+
         answer = nil
 
         paths = @config[:paths].map { |p| Backend.parse_string(p, scope, { 'key' => key }) }


### PR DESCRIPTION
This proposal would supercede #24 

PR #24 suggested a feature to add a "key whitelist" - which was was then updated to support regexes.  Im happy to merge the feature, but theres two minor things I didn't quite like - firstly the name "key whitelist" (to me at least) was a bit confusing, I think "confine_to_keys" is a better name (discuss?)

I think it's better to just make it a list of regexes, rather than strings and regexes.

Also - the implementation of the regex match was a bit odd comparing byte sizes - and Im not convinced Regexp.union is the best way to combine all the regexes, so I've re-written it to match against each regexp individually - at the very least it's a bit more understandable....

I havent had time to test this properly yet, but @quark-zju / @tosmi - does this look like sensible to you?
