### PR TITLE
Fixing YAML parsing for Ruby >= 1.9.3

### DIFF
--- a/lib/hiera/backend/http_backend.rb
+++ b/lib/hiera/backend/http_backend.rb
@@ -100,7 +100,7 @@ class Hiera
 
       def parse_yaml(answer)
         require 'yaml'
-        YAML.parse(answer)
+        YAML.load(answer)
       end
 
       def http_get_and_parse_with_cache(path)


### PR DESCRIPTION
When installing this hiera backend on Ruby 1.9.3 or newer, I receive an error when using yaml as output. The YAML.parse function is replaced by YAML.load.