### PR TITLE
Support array as value for parsing paths.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ The `:paths:` parameter can also parse the lookup key, eg:
     :paths:
       /configuration.php?lookup=%{key}
 
+`:paths_array:` Support array as value for path parsing, eg:
+
+    :paths_array:
+        mykey: /somepath/%{mykey}
+
+If `mykey` is an array like ["one", "two"], it will create /somepath/one and /somepath/two paths.
+If for a reason `mykey` is not an array like "three", it will create  /somepath/three path.
+
 `:use_ssl:`: When set to true, enable SSL (default: false)
 
 `:ssl_ca_cert`: Specify a CA cert for use with SSL

--- a/lib/hiera/backend/http_backend.rb
+++ b/lib/hiera/backend/http_backend.rb
@@ -45,6 +45,33 @@ class Hiera
         end
       end
 
+      def build_paths(key, scope, order_override)
+        paths = @config[:paths].map { |p| Backend.parse_string(p, scope, { 'key' => key }) }
+        # Hiera don't support array as value for parse_string so we add it in config file.
+        # Notes at https://docs.puppetlabs.com/hiera/1/variables.html#interpolation-tokens
+        # We can't get the entire scope so we check if the value exist in the scope
+        # and we try to resolve :paths with this value
+        if !@config[:paths_array].nil?
+          @config[:paths_array].map do |var, p|
+            # if not in scope ignore it
+            if !scope[var].nil?
+              if scope[var].kind_of?(Array)
+                scope[var].each do |v|
+                  paths.push(Backend.parse_string(p, { var => v}, { 'key' => key }))
+                end
+              else
+                # allow non array values too
+                paths.push(Backend.parse_string(p, { var => scope[var]}, { 'key' => key }))
+              end
+            else
+              Hiera.warn("[hiera-http]: Variable #{var} not in scope for path #{p}")
+            end
+          end
+        end
+        paths.insert(0, order_override) if order_override
+        paths
+      end
+
       def lookup(key, scope, order_override, resolution_type)
 
         # if confine_to_keys is configured, then only proceed if one of the
@@ -54,12 +81,9 @@ class Hiera
           return nil unless key[@regex_key_match] == key
         end
 
-
         answer = nil
 
-        paths = @config[:paths].map { |p| Backend.parse_string(p, scope, { 'key' => key }) }
-        paths.insert(0, order_override) if order_override
-
+        paths = build_paths(key, scope, order_override)
 
         paths.each do |path|
 
@@ -178,4 +202,5 @@ class Hiera
     end
   end
 end
+
 


### PR DESCRIPTION
Hiera don't support array as value for parse_string.
Check https://docs.puppetlabs.com/hiera/1/variables.html\#interpolation-tokens
This patch add an option to make the difference between string and array paths.
If it's an array simply create a path with each value in the array.
We can't get the entire scope but we can check the key.
For avoiding rewritring regex we add a key to the path.