### PR TITLE
Fix Issue 46

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,38 @@ The following are optional configuration parameters supported in the `options` h
 
 `:headers:`: Hash of headers to send in the request
 
+### Using the key name as part of the URI
+
+Previous versions of this backed allowed the use of `%{key}` to include the key
+name as part of the URL. Due to API changes in Hiera v5, this interpolation is
+no longer possible. This backend now supports an alternative method to include
+the key name using the `__KEY__` tag.
+
+Example using this backend to interact with the [Puppet Enterprise Jenkins Pipeline plugin](https://wiki.jenkins.io/display/JENKINS/Puppet+Enterprise+Pipeline+Plugin)
+
+```yaml
+---
+version: 5
+
+defaults:
+  datadir: hieradata
+  data_hash: yaml_data
+
+hierarchy:
+  - name: 'Jenkins data source'
+    lookup_key: hiera_http
+    uris:
+      - "http://jenkins.example.com:8080/hiera/lookup?scope=%{::trusted.certname}&key=__KEY__"
+      - "http://jenkins.example.com:8080/hiera/lookup?scope=%{::environment}&key=__KEY__"
+    options:
+      output: json
+      failure: graceful
+#      use_auth: true
+#     auth_user: ''
+#     auth_pass: ''
+
+```
+
 ### Author
 
 * Craig Dunn <craig@craigdunn.org>

--- a/lib/puppet/functions/hiera_http.rb
+++ b/lib/puppet/functions/hiera_http.rb
@@ -26,6 +26,7 @@ Puppet::Functions.create_function(:hiera_http) do
       end
     end
 
+    options['uri'].gsub! '__KEY__', key
     result = http_get(context, options)
 
     answer = result.is_a?(Hash) ? result[key] : result


### PR DESCRIPTION
This PR fixes issue #46: using %{key} in the uri(s) didn't get interpolated
with the key name being looked up. This used to be the behaviour with
hiera v3.

The reason for this is that the new uri(s) options now get interpolated
by expand_uris in location_resolver, even before it reaches the
backend. That meants that by the time the call reaches the hiera
backend, %{key} is no longer there.

I worked around this by implementing a simple string replacement that
looks for __KEY__ and replaces it with the key name.

To verify this change, use `__KEY__` as part of the uri or uris options.
The request should include the name of the key instead of `__KEY__`