### PR TITLE
Add __PARAMETER__, __CLASS__ and __MODULE__ tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 gem 'rspec'
 gem 'lookup_http'
+gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 gem 'rspec'
 gem 'lookup_http'
-gem 'pry'

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The following mandatory Hiera 5 options must be set for each level of the hierar
 
 `name`: A human readable name for the lookup
 `lookup_key`: This option must be set to `hiera_http`
-`uris` or `uri`: An array of URI's passed to `uris` _or_ a single URI passed to `uri`
+`uris` or `uri`: An array of URI's passed to `uris` _or_ a single URI passed to `uri`. This option supports interpolating special tags, see below.
 
 
 The following are optional configuration parameters supported in the `options` hash of the Hiera 5 config
@@ -98,12 +98,16 @@ The following are optional configuration parameters supported in the `options` h
 
 `:headers:`: Hash of headers to send in the request
 
-### Using the key name as part of the URI
+### Interpolating special tags
 
-Previous versions of this backed allowed the use of `%{key}` to include the key
-name as part of the URL. Due to API changes in Hiera v5, this interpolation is
-no longer possible. This backend now supports an alternative method to include
-the key name using the `__KEY__` tag.
+Previous versions of this backed allowed the use of variables such as `%{key}` and `%{calling_module}` to be used in the URL, this has changed with Hiera 5. To allow for similar behaviour you can use a number of tags surrounded by `__` to interpolate special variables derived from the key into the `uri` or `uris` option in hiera.yaml. Currently you can interpolate `__KEY__`, `__MODULE__`, `__CLASS__` and `__PARAMETER__`, these tags are derived from parsing the original lookup key.
+
+In the case of a lookup key matching `foo::bar::tango` the following tags are available;
+
+* `__KEY__` : The original lookup key unchanched; `foo::bar::tango`
+* `__MODULE__` : The first part of the lookup key; `foo`
+* `__CLASS__` : All but the last parts of the lookup key; `foo::bar`
+* `__PARAMETER__` : The last part of they key representing the class parameter; `tango`
 
 Example using this backend to interact with the [Puppet Enterprise Jenkins Pipeline plugin](https://wiki.jenkins.io/display/JENKINS/Puppet+Enterprise+Pipeline+Plugin)
 
@@ -124,10 +128,6 @@ hierarchy:
     options:
       output: json
       failure: graceful
-#      use_auth: true
-#     auth_user: ''
-#     auth_pass: ''
-
 ```
 
 ### Author

--- a/spec/functions/hiera_http_spec.rb
+++ b/spec/functions/hiera_http_spec.rb
@@ -40,6 +40,36 @@ describe FakeFunction do
         expect(@lookuphttp).to receive(:get_parsed).with('/path/foo::bar::tango')
         function.lookup_key('foo::bar::tango', options, @context)
       end
+
+      it "should interpolate __MODULE__ correctly" do
+        options = { 'uri' => 'http://localhost/path/__MODULE__' }
+        expect(@context).to receive(:interpolate).with('/path/foo').and_return('/path/foo')
+        expect(@lookuphttp).to receive(:get_parsed).with('/path/foo')
+        function.lookup_key('foo::bar::tango', options, @context)
+      end
+
+      it "should interpolate __CLASS__ correctly" do
+        options = { 'uri' => 'http://localhost/path/__CLASS__' }
+        expect(@context).to receive(:interpolate).with('/path/foo::bar').and_return('/path/foo::bar')
+        expect(@lookuphttp).to receive(:get_parsed).with('/path/foo::bar')
+        function.lookup_key('foo::bar::tango', options, @context)
+      end
+
+      it "should interpolate __PARAMETER__ correctly" do
+        options = { 'uri' => 'http://localhost/path/__PARAMETER__' }
+        expect(@context).to receive(:interpolate).with('/path/tango').and_return('/path/tango')
+        expect(@lookuphttp).to receive(:get_parsed).with('/path/tango')
+        function.lookup_key('foo::bar::tango', options, @context)
+      end
+
+      it "should interpolate more than one field" do
+        options = { 'uri' => 'http://localhost/path/__MODULE__/__PARAMETER__/__PARAMETER__' }
+        expect(@context).to receive(:interpolate).with('/path/foo/tango/tango').and_return('/path/foo/tango/tango')
+        expect(@lookuphttp).to receive(:get_parsed).with('/path/foo/tango/tango')
+        function.lookup_key('foo::bar::tango', options, @context)
+      end
+
+
     end
 
     context "When confine_to_keys is set" do


### PR DESCRIPTION

In #53 there was a feature introduced to interpolate `__KEY__` into the URI paths to allow for interpolation of the lookup key previously possible with Hiera as `%{key}` but now no longer supported.

As described in #59 this is slightly insufficient for some people as the lookup key also contains the class and module so this PR adds some more flexibility to this idea by also adding `__PARAMETER__` , `__CLASS__` and `__MODULE__`

In the case of a lookup key matching `foo::bar::tango` the following tags are now available;

* `__KEY__` : The original lookup key unchanched; `foo::bar::tango`
* `__MODULE__` : The first part of the lookup key; `foo`
* `__CLASS__` : All but the last parts of the lookup key; `foo::bar`
* `__PARAMETER__` : The last part of they key representing the class parameter; `tango`

ping @soudaburger FYI

Closes #59 
