### PR TITLE
Added json_key option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ hierarchy:
 The following mandatory Hiera 5 options must be set for each level of the hierarchy.
 
 `name`: A human readable name for the lookup
+
 `lookup_key`: This option must be set to `hiera_http`
+
 `uris` or `uri`: An array of URI's passed to `uris` _or_ a single URI passed to `uri`. This option supports interpolating special tags, see below.
 
 
@@ -97,6 +99,8 @@ The following are optional configuration parameters supported in the `options` h
 `:auth_pass:`: The password for basic auth
 
 `:headers:`: Hash of headers to send in the request
+
+`:json_key`: The key in the JSON to pass back to hiera. Will be interpolated with the special tags. Set to false to return the whole JSON to hiera.
 
 ### Interpolating special tags
 

--- a/lib/puppet/functions/hiera_http.rb
+++ b/lib/puppet/functions/hiera_http.rb
@@ -27,10 +27,18 @@ Puppet::Functions.create_function(:hiera_http) do
       end
     end
 
+    json_key = key
+    unless options['json_key'].nil?
+      json_key = options['json_key']
+      if json_key.respond_to?(:gsub)
+        json_key = parse_tags(key, json_key)
+      end
+    end
+
     options['uri'] = parse_tags(key, options['uri'])
     result = http_get(context, options)
 
-    answer = result.is_a?(Hash) ? result[key] : result
+    answer = result.is_a?(Hash) && json_key != false ? result[json_key] : result
     context.not_found if answer.nil?
     return answer
   end


### PR DESCRIPTION
Currently, when using "output": "json", the function will always lookup the full key in the `json` returned by the HTTP endpoint. However, in most cases you do not want that and setting `output` to something else will require you to parse the JSON data in Puppet.

This small change will allow you to set json_key to false if you want to return the full JSON object to Hiera, or set it to a custom key that is, in turn, interpolated with the "special tags".

Backwards compatibility is 100%.

For example, using this function as a Hiera backend for Consul:

```
hierarchy:
  - name: "Consul backend"
    uris:
      - "http://127.0.0.1:8500/v1/__KEY__?raw"
    lookup_key: hiera_http
    options:
      ignore_404: true
      output: json
      json_key: false
```
```
$ echo -n '{"ip":"127.0.0.1","name":"Another test!"}' | consul kv put test/data1 -
```
```
$ puppet lookup test/data1
---
ip: 127.0.0.1
name: Another test!
```
```
$ puppet lookup test/data1.ip
--- 127.0.0.1
...
```
```
$ puppet lookup catalog/services
---
consul: []
...
```
```
$ puppet lookup catalog/nodes.0.Datacenter
--- dc1
...
```