### PR TITLE
Add caching of lookuphttp object.

### DIFF
--- a/lib/puppet/functions/hiera_http.rb
+++ b/lib/puppet/functions/hiera_http.rb
@@ -65,11 +65,17 @@ Puppet::Functions.create_function(:hiera_http) do
       return context.cached_value(path)
     else
       context.explain { "Querying #{uri}" }
-      lookup_params = {}
-      options.each do |k,v|
-        lookup_params[k.to_sym] = v if lookup_supported_params.include?(k.to_sym)
+
+      if context.cache_has_key('__lookuphttp')
+        http_handler = context.cached_value('__lookuphttp')
+      else
+        lookup_params = {}
+        options.each do |k,v|
+          lookup_params[k.to_sym] = v if lookup_supported_params.include?(k.to_sym)
+        end
+        http_handler = LookupHttp.new(lookup_params.merge({:host => host, :port => port}))
+        context.cache('__lookuphttp', http_handler)
       end
-      http_handler = LookupHttp.new(lookup_params.merge({:host => host, :port => port}))
 
       begin
         response = http_handler.get_parsed(path)

--- a/spec/functions/hiera_http_spec.rb
+++ b/spec/functions/hiera_http_spec.rb
@@ -114,6 +114,24 @@ describe FakeFunction do
         'uri' => 'http://localhost/path'
       } }
 
+      it "should use a cached lookuphttp object when available" do
+        expect(@context).to receive(:cache_has_key).with('__lookuphttp').and_return(true)
+        expect(LookupHttp).not_to receive(:new)
+        expect(@context).to receive(:cached_value).with('__lookuphttp').and_return(@lookuphttp)
+        expect(@lookuphttp).to receive(:get_parsed).and_return({ 'tango' => 'bar'})
+        expect(function.lookup_key('tango', options, @context)).to eq('bar')
+      end
+
+
+      it "should create a new lookuphttp object when not cached" do
+        expect(@context).to receive(:cache_has_key).with('__lookuphttp').and_return(false)
+        expect(LookupHttp).to receive(:new).and_return(@lookuphttp)
+        expect(@context).not_to receive(:cached_value).with('__lookuphttp')
+        expect(@lookuphttp).to receive(:get_parsed).and_return({ 'tango' => 'bar'})
+        expect(function.lookup_key('tango', options, @context)).to eq('bar')
+      end
+
+
       it "should used cached value when available" do
         expect(@context).to receive(:cache_has_key).with('/path').and_return(true)
         expect(@context).to receive(:cached_value).with('/path').and_return({ 'tango' => 'bar'})


### PR DESCRIPTION

Currently, each individual lookup creates a new `LookupHttp` instance, which adds some overhead doing things like parsing SSL certificates on every lookup..etc.   This PR adds extra functionality to cache the lookup_http object between lookups within a single hierarchy level in a single Puppet run.