### PR TITLE
fixed issue with nil values causing exception in dig

### DIFF
--- a/lib/puppet/functions/hiera_http.rb
+++ b/lib/puppet/functions/hiera_http.rb
@@ -54,10 +54,12 @@ Puppet::Functions.create_function(:hiera_http) do
     dig_path = dig_key.split(/\./).map { |p| parse_tags(key, p) }
 
 
-    if result.is_a?(String)
-      return result
-    else
+    if result.nil?
+      return :not_found
+    elsif result.is_a?(Hash)
       return dig ? hash_dig(result, dig_path) : result
+    else
+      return result
     end
 
   end

--- a/spec/functions/hiera_http_spec.rb
+++ b/spec/functions/hiera_http_spec.rb
@@ -159,6 +159,12 @@ describe FakeFunction do
         expect(@context).to receive(:not_found)
         expect(function.lookup_key('config', options, @context)).to eq(nil)
       end
+
+      it "should return not_found when a nil value is returned" do
+        expect(@lookuphttp).to receive(:get_parsed).and_return(nil)
+        expect(@context).to receive(:not_found)
+        expect(function.lookup_key('foo', options, @context)).to eq(nil)
+      end
     end
         
 


### PR DESCRIPTION

The dig feature introduced in #66 (Issue #65 ) caused exceptions when dealing with nil values returned from the HTTP request - the correct behaviour should be `:not_found`

FYI @FlorinAsavoaie  

