### PR TITLE
remove URI escaping

### DIFF
--- a/lib/puppet/functions/hiera_http.rb
+++ b/lib/puppet/functions/hiera_http.rb
@@ -102,7 +102,7 @@ Puppet::Functions.create_function(:hiera_http) do
 
   def http_get(context, options)
     uri = URI.parse(options['uri'])
-    host, port, path = uri.host, uri.port, URI.escape(context.interpolate(uri.request_uri))
+    host, port, path = uri.host, uri.port, context.interpolate(uri.request_uri)
 
     if context.cache_has_key(path)
       context.explain { "Returning cached value for #{path}" }


### PR DESCRIPTION
This is a possible fix for issue #79. Maybe this should be configurable. I am not really sure. I am doubtful, though, that it is doing much for anyone, because as I mentioned on the issue, it's not possible to use interpolated values that require escaping at all right now, because then Hiera itself fails inside `expand_uris`.